### PR TITLE
compatibility with PHP < 8.x

### DIFF
--- a/SessionViewer.module
+++ b/SessionViewer.module
@@ -7,11 +7,19 @@
  * @author tech-c.net
  * @license Licensed under GNU/GPL v2
  * @link https://tech-c.net/posts/session-viewer-for-processwire/
- * @version 1.0.2
+ * @version 1.0.3
  * 
  * @see Forum Thread: https://processwire.com/talk/topic/26238-session-viewer/
  * @see Donate: https://www.paypal.me/techcnet/
  */
+/**
+ * Compatibility for PHP versions < 8
+ */
+if (!function_exists('str_starts_with')) {
+  function str_starts_with($haystack, $needle) {
+      return (string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0;
+  }
+}
 
 class SessionViewer extends Process {
   const PageName = 'session-viewer';
@@ -28,7 +36,7 @@ class SessionViewer extends Process {
       'summary' => 'Lists all session files and displays the session data.',
       'href' => 'https://tech-c.net/posts/session-viewer-for-processwire/',
       'author' => 'tech-c.net',
-      'version' => 102,
+      'version' => 103,
       'icon' => 'id-card',
       'permission' => self::PagePermission,
       'autoload' => false,

--- a/SessionViewerConfig.php
+++ b/SessionViewerConfig.php
@@ -7,7 +7,7 @@
  * @author tech-c.net
  * @license Licensed under GNU/GPL v2
  * @link https://tech-c.net/posts/session-viewer-for-processwire/
- * @version 1.0.2
+ * @version 1.0.3
  * 
  * @see Forum Thread: https://processwire.com/talk/topic/26238-session-viewer/
  * @see Donate: https://www.paypal.me/techcnet/


### PR DESCRIPTION
Since I ran into this issue on PHP 7.4:
```
Fatal Error: Uncaught Error: Call to undefined function str_starts_with() in site/modules/SessionViewer/SessionViewer.module:212

#0 wire/core/Wire.php (414): SessionViewer->___execute()
#1 wire/core/WireHooks.php (951): Wire->_callMethod('___execute', Array)
#2 wire/core/Wire.php (485): WireHooks->runHooks(Object(SessionViewer), 'execute', Array)
#3 wire/core/ProcessController.php (337): Wire->__call('execute', Array)
#4 wire/core/Wire.php (414): ProcessController->___execute()
#5 wire/core/WireHooks.php (951): Wire->_callMethod('___execute', Array)
#6 wire/core/Wire.php (485): WireHooks->runHooks(Object(ProcessController), 'execute', Arra (line 212 of site/modules/SessionViewer/SessionViewer.module) 
```
I created a small fix for it and added a function to allow module execution with PHP < 8. I'm not sure what the minimal required PHP version now is, but at least 7.4 does work now.